### PR TITLE
fixed queue capacity to 1000

### DIFF
--- a/iaq-station/application/infrastructure/queue/circular_priority_sensor_queue.py
+++ b/iaq-station/application/infrastructure/queue/circular_priority_sensor_queue.py
@@ -10,7 +10,7 @@ class CircularPrioritySensorQueue(SensorQueue):
      When the queue is full, the older data will be overridden by most recent data.
     """
 
-    def __init__(self, name="", capacity=100):
+    def __init__(self, name="", capacity=1000):
         super().__init__(name)
         self.queue = PriorityQueue(capacity)
         self.capacity = capacity


### PR DESCRIPTION
if for some reason the raspberry can't send the sensor data, it will put the value back in the queue. What would be a good capacity for these queues?

each sensor read is about 80 bytes in size. Assuming a read every second, that would be 60/5 = 12 reads every minute.
12x60 = 720 should be the capacity for one hour. using 1000 should give us 1.5 hours more or less.